### PR TITLE
Fix trust remote code

### DIFF
--- a/src/open_clip/hf_model.py
+++ b/src/open_clip/hf_model.py
@@ -106,6 +106,7 @@ class HFTextEncoder(nn.Module):
             proj_type: str = None,
             pretrained: bool = True,
             output_tokens: bool = False,
+            trust_remote_code: bool = False,
     ):
         super().__init__()
         self.output_tokens = output_tokens
@@ -117,7 +118,7 @@ class HFTextEncoder(nn.Module):
         if transformers is None:
             raise RuntimeError("Please `pip install transformers` to use pre-trained HuggingFace models")
         if config is None:
-            self.config = AutoConfig.from_pretrained(model_name_or_path)
+            self.config = AutoConfig.from_pretrained(model_name_or_path,trust_remote_code=trust_remote_code)
             create_func, model_args = (AutoModel.from_pretrained, model_name_or_path) if pretrained else (
                 AutoModel.from_config, self.config)
             # TODO: do all model configs have this attribute? PretrainedConfig does so yes??
@@ -125,7 +126,7 @@ class HFTextEncoder(nn.Module):
                 self.transformer = create_func(model_args)
                 self.transformer = self.transformer.encoder
             else:
-                self.transformer = create_func(model_args, add_pooling_layer=uses_transformer_pooler)
+                self.transformer = create_func(model_args, trust_remote_code=trust_remote_code, add_pooling_layer=uses_transformer_pooler)
         else:
             self.config = config
             self.transformer = AutoModel.from_config(config)

--- a/src/open_clip/hf_model.py
+++ b/src/open_clip/hf_model.py
@@ -118,7 +118,7 @@ class HFTextEncoder(nn.Module):
         if transformers is None:
             raise RuntimeError("Please `pip install transformers` to use pre-trained HuggingFace models")
         if config is None:
-            self.config = AutoConfig.from_pretrained(model_name_or_path,trust_remote_code=trust_remote_code)
+            self.config = AutoConfig.from_pretrained(model_name_or_path, trust_remote_code=trust_remote_code)
             create_func, model_args = (AutoModel.from_pretrained, model_name_or_path) if pretrained else (
                 AutoModel.from_config, self.config)
             # TODO: do all model configs have this attribute? PretrainedConfig does so yes??

--- a/src/open_clip/model.py
+++ b/src/open_clip/model.py
@@ -81,6 +81,7 @@ class CLIPTextCfg:
     hf_model_pretrained: bool = True
     hf_proj_type: str = 'mlp'
     hf_pooler_type: str = 'mean_pooler'  # attentional pooling for HF models
+    hf_trust_remote_code: bool = False
 
 
 def get_cast_dtype(precision: str):
@@ -187,6 +188,7 @@ def _build_text_tower(
             pooler_type=text_cfg.hf_pooler_type,
             pretrained=text_cfg.hf_model_pretrained,
             output_tokens=text_cfg.output_tokens,
+            trust_remote_code=text_cfg.hf_trust_remote_code
         )
     else:
         act_layer = QuickGELU if quick_gelu else nn.GELU

--- a/src/training/distributed.py
+++ b/src/training/distributed.py
@@ -1,4 +1,5 @@
 import os
+from datetime import timedelta
 
 import torch
 import torch.distributed as dist
@@ -90,13 +91,15 @@ def init_distributed_device(args):
                 init_method=args.dist_url,
                 world_size=args.world_size,
                 rank=args.rank,
+                timeout=timedelta(seconds=3000)
             )
         else:
             # DDP via torchrun, torch.distributed.launch
             args.local_rank, _, _ = world_info_from_env()
             torch.distributed.init_process_group(
                 backend=args.dist_backend,
-                init_method=args.dist_url)
+                init_method=args.dist_url,
+                timeout=timedelta(seconds=3000))
             args.world_size = torch.distributed.get_world_size()
             args.rank = torch.distributed.get_rank()
         args.distributed = True

--- a/src/training/evaluate.py
+++ b/src/training/evaluate.py
@@ -24,6 +24,7 @@ from open_clip import (
 from .distributed import is_master
 from .precision import get_autocast
 
+MTEB_LOGGING_METRICS = ['ncdg_at_10', 'cos_sim']
 
 def _get_clip_metrics(image_features, text_features, logit_scale):
     metrics = {}
@@ -410,7 +411,7 @@ def _run_mteb_benchmark(model, tokenizer, epoch, args):
         )
         metrics.update({
             k: v
-            for k, v in flatten(results, separator='-').items() if isinstance(v, float)
+            for k, v in flatten(results, separator='-').items() if isinstance(v, float) and any(sub in k for sub in MTEB_LOGGING_METRICS)
         })
     
     logging.info('Finished MTEB benchmark!')

--- a/src/training/evaluate.py
+++ b/src/training/evaluate.py
@@ -24,7 +24,7 @@ from open_clip import (
 from .distributed import is_master
 from .precision import get_autocast
 
-MTEB_LOGGING_METRICS = ['ncdg_at_10', 'cos_sim']
+MTEB_LOGGING_METRICS = ['ndcg_at_10', 'cos_sim']
 
 def _get_clip_metrics(image_features, text_features, logit_scale):
     metrics = {}

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -430,6 +430,10 @@ def main(args):
         )
         return
 
+    evaluate(
+            model, preprocess_val, tokenizer, data, start_epoch, args, tb_writer=writer,
+        )
+        
     loss = create_loss(args)
 
     for epoch in range(start_epoch, args.epochs):

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -429,11 +429,12 @@ def main(args):
             model, preprocess_val, tokenizer, data, start_epoch, args, tb_writer=writer,
         )
         return
+    
+    if args.evaluate_on_start:
+        evaluate(
+                model, preprocess_val, tokenizer, data, start_epoch, args, tb_writer=writer,
+            )
 
-    evaluate(
-            model, preprocess_val, tokenizer, data, start_epoch, args, tb_writer=writer,
-        )
-        
     loss = create_loss(args)
 
     for epoch in range(start_epoch, args.epochs):
@@ -442,20 +443,6 @@ def main(args):
 
         train_one_epoch(model, data, loss, epoch, optimizer, scaler, scheduler, dist_model, args, tb_writer=writer)
         completed_epoch = epoch + 1
-
-        if (
-            any(v in data for v in ('val', 'imagenet-val', 'imagenet-v2'))
-            or args.clip_benchmark_frequency != 0
-        ):
-            evaluate(
-                model,
-                preprocess_val,
-                tokenizer,
-                data,
-                completed_epoch,
-                args,
-                tb_writer=writer,
-            )
 
         # Saving checkpoints.
         if args.save_logs:
@@ -486,6 +473,20 @@ def main(args):
                 latest_save_path = os.path.join(args.checkpoint_path, LATEST_CHECKPOINT_NAME)
                 torch.save(checkpoint_dict, tmp_save_path)
                 os.replace(tmp_save_path, latest_save_path)
+
+        if (
+            any(v in data for v in ('val', 'imagenet-val', 'imagenet-v2'))
+            or args.clip_benchmark_frequency != 0
+        ):
+            evaluate(
+                model,
+                preprocess_val,
+                tokenizer,
+                data,
+                completed_epoch,
+                args,
+                tb_writer=writer,
+            )
 
     if args.wandb and is_master(args):
         wandb.finish()

--- a/src/training/main.py
+++ b/src/training/main.py
@@ -477,6 +477,7 @@ def main(args):
         if (
             any(v in data for v in ('val', 'imagenet-val', 'imagenet-v2'))
             or args.clip_benchmark_frequency != 0
+            or args.mteb_frequency != 0
         ):
             evaluate(
                 model,

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -169,6 +169,12 @@ def parse_args(args):
         "--save-frequency", type=int, default=1, help="How often to save checkpoints."
     )
     parser.add_argument(
+        "--evaluate-on-start",
+        action="store_true",
+        default=False,
+        help="Do the first evaluation on the benchmarks before start training"
+    )
+    parser.add_argument(
         "--save-most-recent",
         action="store_true",
         default=False,

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -172,7 +172,7 @@ def parse_args(args):
         "--evaluate-on-start",
         action="store_true",
         default=False,
-        help="Do the first evaluation on the benchmarks before start training"
+        help="Run the first benchmark evaluation before training"
     )
     parser.add_argument(
         "--save-most-recent",


### PR DESCRIPTION
1. fix the issue with trust remote code in order to load jina-models, we should add the "hf_trust_remote_code": true variable in txt_cfg in the model_config.json file in order to enable it.
2. log only the specific metrics.
3. Do evaluation on the benchmarks at the beginning of the training.
4. Increase the timeout time to block the distributed process to die from timeout during evaluation.